### PR TITLE
Required changes after upgrading postgres jdbc driver to 42.3.3

### DIFF
--- a/3-integration/connect-db/postgres/src/main/docker/Dockerfile
+++ b/3-integration/connect-db/postgres/src/main/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
 COPY --chown=1001:0 ${project.artifactId}.war /config/apps/
-COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources/
+COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.3.3.jar /opt/ol/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/3-integration/connect-db/postgres/src/main/docker/Dockerfile-local
+++ b/3-integration/connect-db/postgres/src/main/docker/Dockerfile-local
@@ -5,7 +5,7 @@ FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config/bootstrap.properties
 COPY --chown=1001:0 ${project.artifactId}.war /config/apps/
-COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources/
+COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.3.3.jar /opt/ol/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/3-integration/connect-db/postgres/src/main/docker/Dockerfile-wlp
+++ b/3-integration/connect-db/postgres/src/main/docker/Dockerfile-wlp
@@ -4,7 +4,7 @@ FROM ibmcom/websphere-liberty:full-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
 COPY --chown=1001:0 ${project.artifactId}.war /config/apps/
-COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
+COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.3.3.jar /opt/ibm/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/3-integration/connect-db/postgres/src/main/docker/Dockerfile-wlp-local
+++ b/3-integration/connect-db/postgres/src/main/docker/Dockerfile-wlp-local
@@ -5,7 +5,7 @@ FROM ibmcom/websphere-liberty:full-java8-openj9-ubi
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config/bootstrap.properties
 COPY --chown=1001:0 ${project.artifactId}.war /config/apps/
-COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
+COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.3.3.jar /opt/ibm/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/3-integration/connect-db/postgres/src/main/liberty/config/server.xml
+++ b/3-integration/connect-db/postgres/src/main/liberty/config/server.xml
@@ -32,7 +32,7 @@
             password="${db.password}"
             ssl="${db.ssl}" />
     </dataSource>
-    <variable name="db.ssl" defaultValue="true"/>
+    <variable name="db.ssl" defaultValue="false"/>
 
     <library id="driver-library">
         <fileset dir="${shared.resource.dir}" includes="*.jar" />

--- a/3-integration/session-persistence/database-oidc/Dockerfile
+++ b/3-integration/session-persistence/database-oidc/Dockerfile
@@ -4,7 +4,7 @@ FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 src/main/liberty/config/server.xml /config/server.xml
 COPY --chown=1001:0 target/javaee-cafe.war /config/apps/
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources/
+COPY --chown=1001:0 postgresql-42.3.3.jar /opt/ol/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/3-integration/session-persistence/database-oidc/Dockerfile-wlp
+++ b/3-integration/session-persistence/database-oidc/Dockerfile-wlp
@@ -4,7 +4,7 @@ FROM ibmcom/websphere-liberty:kernel-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 src/main/liberty/config/server.xml /config/server.xml
 COPY --chown=1001:0 target/javaee-cafe.war /config/apps/
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
+COPY --chown=1001:0 postgresql-42.3.3.jar /opt/ibm/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/3-integration/session-persistence/database-oidc/src/main/liberty/config/server.xml
+++ b/3-integration/session-persistence/database-oidc/src/main/liberty/config/server.xml
@@ -82,7 +82,7 @@
             password="${db.password}"
             ssl="${db.ssl}" />
     </dataSource>
-    <variable name="db.ssl" defaultValue="true"/>
+    <variable name="db.ssl" defaultValue="false"/>
 
     <library id="driver-library">
         <fileset dir="${shared.resource.dir}" includes="*.jar" />

--- a/3-integration/session-persistence/database-ssl/Dockerfile
+++ b/3-integration/session-persistence/database-ssl/Dockerfile
@@ -4,7 +4,7 @@ FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 src/main/liberty/config/server.xml /config/server.xml
 COPY --chown=1001:0 target/javaee-cafe.war /config/apps/
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources/
+COPY --chown=1001:0 postgresql-42.3.3.jar /opt/ol/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/3-integration/session-persistence/database-ssl/Dockerfile-wlp
+++ b/3-integration/session-persistence/database-ssl/Dockerfile-wlp
@@ -4,7 +4,7 @@ FROM ibmcom/websphere-liberty:kernel-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 src/main/liberty/config/server.xml /config/server.xml
 COPY --chown=1001:0 target/javaee-cafe.war /config/apps/
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
+COPY --chown=1001:0 postgresql-42.3.3.jar /opt/ibm/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/3-integration/session-persistence/database-ssl/src/main/liberty/config/server.xml
+++ b/3-integration/session-persistence/database-ssl/src/main/liberty/config/server.xml
@@ -50,7 +50,7 @@
             password="${db.password}"
             ssl="${db.ssl}" />
     </dataSource>
-    <variable name="db.ssl" defaultValue="true"/>
+    <variable name="db.ssl" defaultValue="false"/>
 
     <library id="driver-library">
         <fileset dir="${shared.resource.dir}" includes="*.jar" />

--- a/3-integration/session-persistence/jcache-datagrid/Dockerfile
+++ b/3-integration/session-persistence/jcache-datagrid/Dockerfile
@@ -4,7 +4,7 @@ FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 # Add config, app, jdbc driver & infinispan libs
 COPY --chown=1001:0 src/main/liberty/config/server.xml /config/server.xml
 COPY --chown=1001:0 target/javaee-cafe.war /config/apps/
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources/
+COPY --chown=1001:0 postgresql-42.3.3.jar /opt/ol/wlp/usr/shared/resources/
 ADD --chown=1001:0 infinispan /opt/ol/wlp/usr/shared/resources/infinispan
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes

--- a/3-integration/session-persistence/jcache-datagrid/Dockerfile-wlp
+++ b/3-integration/session-persistence/jcache-datagrid/Dockerfile-wlp
@@ -4,7 +4,7 @@ FROM ibmcom/websphere-liberty:kernel-java8-openj9-ubi
 # Add config, app, jdbc driver & infinispan libs
 COPY --chown=1001:0 src/main/liberty/config/server.xml /config/server.xml
 COPY --chown=1001:0 target/javaee-cafe.war /config/apps/
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
+COPY --chown=1001:0 postgresql-42.3.3.jar /opt/ibm/wlp/usr/shared/resources/
 ADD --chown=1001:0 infinispan /opt/ibm/wlp/usr/shared/resources/infinispan
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes

--- a/3-integration/session-persistence/jcache-datagrid/src/main/liberty/config/server.xml
+++ b/3-integration/session-persistence/jcache-datagrid/src/main/liberty/config/server.xml
@@ -56,7 +56,7 @@
             password="${db.password}"
             ssl="${db.ssl}" />
     </dataSource>
-    <variable name="db.ssl" defaultValue="true"/>
+    <variable name="db.ssl" defaultValue="false"/>
 
     <library id="driver-library">
         <fileset dir="${shared.resource.dir}" includes="*.jar" />

--- a/4-finish/Dockerfile
+++ b/4-finish/Dockerfile
@@ -4,7 +4,7 @@ FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 src/main/liberty/config/server.xml /config/server.xml
 COPY --chown=1001:0 target/javaee-cafe.war /config/apps/
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources/
+COPY --chown=1001:0 postgresql-42.3.3.jar /opt/ol/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/4-finish/Dockerfile-wlp
+++ b/4-finish/Dockerfile-wlp
@@ -4,7 +4,7 @@ FROM ibmcom/websphere-liberty:kernel-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 src/main/liberty/config/server.xml /config/server.xml
 COPY --chown=1001:0 target/javaee-cafe.war /config/apps/
-COPY --chown=1001:0 postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
+COPY --chown=1001:0 postgresql-42.3.3.jar /opt/ibm/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/4-finish/src/main/liberty/config/server.xml
+++ b/4-finish/src/main/liberty/config/server.xml
@@ -68,7 +68,7 @@
             password="${db.password}"
             ssl="${db.ssl}" />
     </dataSource>
-    <variable name="db.ssl" defaultValue="true"/>
+    <variable name="db.ssl" defaultValue="false"/>
 
     <library id="driver-library">
         <fileset dir="${shared.resource.dir}" includes="*.jar" />

--- a/guides/howto-integrate-all.md
+++ b/guides/howto-integrate-all.md
@@ -67,7 +67,7 @@ To build the application image, Dockerfile needs to be prepared in advance:
 Follow steps below to build the application image and push it to the built-in container image registry:
 
 1. Change directory to `<path-to-repo>/4-finish` of your local clone.
-2. Download [postgresql-42.2.4.jar](https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.4/postgresql-42.2.4.jar) and put it to current working directory.
+2. Download [postgresql-42.3.3.jar](https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.3/postgresql-42.3.3.jar) and put it to current working directory.
 3. Log in to the OpenShift web console from your browser using the credentials of the Azure AD user.
 4. [Log in to the OpenShift CLI with the token for the Azure AD user](howto-deploy-java-liberty-app.md#log-in-to-the-openshift-cli-with-the-token).
 5. Run the following commands to build application image and push it to the registry.

--- a/guides/howto-integrate-azure-managed-databases.md
+++ b/guides/howto-integrate-azure-managed-databases.md
@@ -235,7 +235,7 @@ To build the application image, Dockerfile needs to be prepared in advance:
 Follow steps below to build the application image:
 
 1. Change directory to `<path-to-repo>/3-integration/connect-db/postgres` of your local clone.
-2. Download [postgresql-42.2.4.jar](https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.4/postgresql-42.2.4.jar) and put it to current working directory.
+2. Download [postgresql-42.3.3.jar](https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.3/postgresql-42.3.3.jar) and put it to current working directory.
 3. Run the following commands to build application image.
 
    ```bash


### PR DESCRIPTION
## Description

This PR targets to fix the new issues after upgrading postgres jdbc driver to 42.3.3 which was introduced by #12, #13, #14, #15 and #16. 

## Change summary:
* Change to postgresql-42.3.3.jar in Dockerfile 
* Workaround ssl certificate restriction after upgrading postgres jdbc driver to 42.3.3 (see https://github.com/cloudcaptainsh/cloudcaptain/issues/234 for more info):
   ```
   Internal Exception: java.sql.SQLException: Could not open SSL root certificate file //.postgresql/root.crt
   ```

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>